### PR TITLE
Let #get accept a query object and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Hooks let you specify custom logic when certain things have happened. The curren
 * `afterSave` — Called after both creates and updates
 * `afterUpdate`
 * `afterCreate`
+* `afterFetch` – Called after a row or rows are returned from the database
 
 ```javascript
 var User = sqlbox.create({

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ User.all({age: 25}, function (err, users) {
 If you want to limit or skip rows, you can specify that option.
 
 ```javascript
-User.all({age: 25}, {limit: 10, skip:10}, function (err, users) {
+User.all({age: 25}, {limit: 10, offset:10}, function (err, users) {
   // ...
 });
 ```

--- a/lib/model_methods.js
+++ b/lib/model_methods.js
@@ -47,7 +47,8 @@ var _ = require('underscore')
  *
  * @param box Object The model that defines the column spec
  * @param obj Object The data to transform
- * @returns Object The transformed object that comforms to the column spec
+ * @param callback Function(err Error, obj Object)
+ * @returns null
  */
 function build(box, obj, callback) {
   var instance = pruneToColumns(box, obj);
@@ -86,14 +87,15 @@ function build(box, obj, callback) {
  *
  * @param box Object The model instance. This parameter is not specified when
  *        using the method through a model instance
- * @param id Number The id of the row to fetch
+ * @param idOrQuery Number|Object The id of the row to fetch or a query
+ *        object
  * @param [opts] Object
  * @param [callback] Function(err Error, row Object)
  * 
  * @returns null|Function null if a callback was specified else a partially
  *          applied version of `get` is returned.
  */
-function get(box, id, opts, callback) {
+function get(box, idOrQuery, opts, callback) {
   // Shift around the arguments to allow optional opts
   if (arguments.length === 2) {
     opts = {};
@@ -104,25 +106,26 @@ function get(box, id, opts, callback) {
 
   // If there is no callback, return a partially applied function
   if (!callback) {
-    return _.partial(get, box, id, opts);
+    return _.partial(get, box, idOrQuery, opts);
   }
 
-  // Check to make sure we don't actually just have the object already, this
-  // helps in code reuse where you might have the object or id.
-  if (typeof id === 'object') {
-    return id;
+  var query;
+  if (typeof idOrQuery === 'object') {
+    query = idOrQuery;
+  } else {
+    query = {id: Number(idOrQuery)};
   }
 
   opts.limit = 1;
   opts.skip = 0;
 
-  box.first({id: Number(id)}, opts, function get_(err, object) {
+  box.first(query, opts, function get_(err, object) {
     if (err) {
       return callback(err);
     }
 
     if (!object) {
-      return callback(new BoxError(404, 'Row with id ' + id + ' was not found in ' + box.name));
+      return callback(new BoxError(404, 'Row with id ' + idOrQuery + ' was not found in ' + box.name));
     }
 
     callback(null, object);

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -114,6 +114,16 @@ describe('sqlbox model', function () {
       });
     });
 
+    it('should accept a query object in addition to an id', function (done) {
+      Person.get({accoundId: 0}, function (err, res) {
+        expect(err).to.be(null);
+        expect(res).to.be.an('object');
+        expect(res.name).to.be('Jim');
+        expect(res.age).to.be(25);
+        done();
+      });
+    })
+
     it('should return an error for non existing row', function (done) {
       Person.get(1000, function (err, res) {
         expect(err).to.be.an(Error);


### PR DESCRIPTION
The #get model method now accepts an id or a query object. This addresses the use-case where an error is desired when a row is not found, but the query is on a column other than id.

In addition, I've added documentation around the afterFetch hook and fixed a documentation typo.
