### PR TITLE
Upgraded any-db to 2.1.x

### DIFF
--- a/lib/dialects/mysql.js
+++ b/lib/dialects/mysql.js
@@ -69,14 +69,31 @@ exports.getUpdateQuery = function (box, where, whereClause, obj) {
 };
 
 /**
+ * Creates a delete query for a box.
+ *
+ * @param box Object The model that defines the column spec
+ * @param id Number The id of the row to remove
+ * @returns Object The query object.
+ */
+
+exports.getDeleteQuery = function (box, id) {
+  var t = box.table;
+
+  var sql = t.delete().where(
+        t.id.equals(Number(id))
+      );
+
+  return sql.toQuery();
+};
+
+/**
  * Gets the number of rows saved.
  *
  * @param result Object The result returned by the SQL client.
  * @returns Number The number of saved rows.
  */
 exports.getSavedRowCount = function (result) {
-  return (result.rows && result.rows[0].affectedRows && result.rows[1]) ? 
-    result.rows[1].length : 0;
+  return result.rows.length;
 };
 
 /**
@@ -86,7 +103,7 @@ exports.getSavedRowCount = function (result) {
  * @returns Number The number of removed rows.
  */
 exports.getRemovedRowCount = function (result) {
-  return result.rows.affectedRows;
+  return result.affectedRows;
 };
 
 /**
@@ -96,7 +113,7 @@ exports.getRemovedRowCount = function (result) {
  * @returns Object The row saved to the database.
  */
 exports.getSavedRecord = function (result) {
-  return result.rows[1][0];
+  return result.rows[0];
 };
 
 /**

--- a/lib/dialects/postgres.js
+++ b/lib/dialects/postgres.js
@@ -59,6 +59,24 @@ exports.getUpdateQuery = function (box, where, whereClause, obj) {
 };
 
 /**
+ * Creates a delete query for a box.
+ *
+ * @param box Object The model that defines the column spec
+ * @param id Number The id of the row to remove
+ * @returns Object The query object.
+ */
+
+exports.getDeleteQuery = function (box, id) {
+  var t = box.table;
+
+  var sql = t.delete().where(
+        t.id.equals(Number(id))
+      ).returning(t.star());
+
+  return sql.toQuery();
+};
+
+/**
  * Gets the number of rows saved.
  *
  * @param result Object The result returned by the SQL client.

--- a/lib/model_methods.js
+++ b/lib/model_methods.js
@@ -242,7 +242,9 @@ function save(model, obj, where, mainCallback) {
   }, function (err, results) {
     // If there is an error, we need to roll the transaction back
     if (err) {
-      model.client.query('ROLLBACK');
+      model.client.query('ROLLBACK', function(err, result) {
+
+      });
     }
 
     // If the error is 304, we just return the unchanged clone
@@ -294,18 +296,11 @@ function remove(model, id, callback) {
     return _.partial(remove, model, id);
   }
 
-  var t = model.table;
-
-  // DELETE FROM table WHERE table.id = $id;
-  var sql = t.delete().where(
-        t.id.equals(Number(id))
-      );
+  var query = dialect.getDeleteQuery(model, id);
 
   if (model.logQueries) {
-    console.log(sql.toString());
+    console.log(query.text);
   }
-
-  var query = sql.toQuery();
 
   model.client.query(query.text, query.values, function remove_(err, result) {
     if (err) {
@@ -698,7 +693,7 @@ function saveNew(model, obj, callback) {
       });
     } else {
       var msg = dialect.name + ' returned no error, but no row was returned.';
-      callback(new BoxError(500, message));
+      callback(new BoxError(500, msg));
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "pluralize": "0.0.5"
   },
   "peerDependencies": {
-    "any-db": "~1.0.0"
+    "any-db": "~2.1.0"
   },
   "devDependencies": {
     "nodemon": "~0.7.8",
     "mocha": "~1.12.0",
     "expect.js": "~0.2.0",
-    "any-db-postgres": "~1.0.0",
-    "any-db-mysql": "~1.0.0"
+    "any-db-postgres": "~2.1.1",
+    "any-db-mysql": "~2.1.1"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
I upgraded any-db to 2.1.x.  A few modifications were needed in the dialects for some updates any-db made.

Unfortunately, there are currently 2 failing tests for mysql. They are:
- MySQL sqlbox model #save on an existing object should error 409 if where clause fails:
- MySQL sqlbox model #modify should pass back 409 error if where clause fails:

I think it may be because of the way the update is constructed. It currently uses `LAST_INSERT_ID()` to select the updated row, which may select a row that was not the most recently updated one. I'm not a mysql expert so I could be wrong. But I'd like to hear your thoughts so that I can get these tests passing.
