### PR TITLE
Updated #remove to accept a query object

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,10 +244,14 @@ All hooks and the actual save are by default contained in a SQL transaction. Thi
 
 #### get
 
-Get a single row by id. If it is not found an error with code 404 will be passed back.
+Get a single row by id or query object. If it is not found an error with code 404 will be passed back.
 
 ```javascript
 User.get(1, function (err, user) {
+  // ...
+});
+
+User.get({username: 'raycmorgan'}, function (err, user) {
   // ...
 });
 ```
@@ -496,10 +500,14 @@ User.save({name: 'Jim', age: '25'}, function (err, user) {
 
 ### Deleting records
 
-You can delete a record by its id. In the callback you will be passed a potential error and a boolean indicating whether or not the record was removed.
+You can delete a record by its id or a query object. In the callback you will be passed a potential error and a boolean indicating whether or not the record was removed.
 
 ```javascript
 User.remove(1, function (err, success) {
+  // ...
+});
+
+User.remove({username: 'raycmorgan'}, function (err, success) {
   // ...
 });
 ```

--- a/lib/dialects/mysql.js
+++ b/lib/dialects/mysql.js
@@ -72,16 +72,15 @@ exports.getUpdateQuery = function (box, where, whereClause, obj) {
  * Creates a delete query for a box.
  *
  * @param box Object The model that defines the column spec
- * @param id Number The id of the row to remove
+ * @param where Object The where properties object
+ * @param whereClause Function The whereClause builder function
  * @returns Object The query object.
  */
-
-exports.getDeleteQuery = function (box, id) {
+exports.getDeleteQuery = function (box, where, whereClause) {
   var t = box.table;
 
-  var sql = t.delete().where(
-        t.id.equals(Number(id))
-      );
+  var sql = t.delete();
+  sql = whereClause(box, sql, where);
 
   return sql.toQuery();
 };

--- a/lib/dialects/postgres.js
+++ b/lib/dialects/postgres.js
@@ -62,16 +62,16 @@ exports.getUpdateQuery = function (box, where, whereClause, obj) {
  * Creates a delete query for a box.
  *
  * @param box Object The model that defines the column spec
- * @param id Number The id of the row to remove
+ * @param where Object The where properties object
+ * @param whereClause Function The whereClause builder function
  * @returns Object The query object.
  */
-
-exports.getDeleteQuery = function (box, id) {
+ exports.getDeleteQuery = function (box, where, whereClause) {
   var t = box.table;
 
-  var sql = t.delete().where(
-        t.id.equals(Number(id))
-      ).returning(t.star());
+  var sql = t.delete();
+  sql = whereClause(box, sql, where);
+  sql = sql.returning(t.star());
 
   return sql.toQuery();
 };

--- a/lib/model_methods.js
+++ b/lib/model_methods.js
@@ -285,18 +285,26 @@ function save(model, obj, where, mainCallback) {
  *
  * @param model Object The model instance. This parameter is not specified when
  *        using the method through a model instance 
- * @param id Number The id of the row to remove
+ * @param idOrProperties Number|Object The id of the row to remove or a query
+ *        object
  * @param [callback] Function(err Error, success Boolean)
  *
  * @returns null|Function null if a callback was specified else a partially
  *          applied version of `remove` is returned.
  */
-function remove(model, id, callback) {
+function remove(model, idOrProperties, callback) {
   if (!callback) {
     return _.partial(remove, model, id);
   }
 
-  var query = dialect.getDeleteQuery(model, id);
+  var properties;
+  if (typeof idOrProperties === 'object') {
+    properties = idOrProperties;
+  } else {
+    properties = {id: Number(idOrProperties)};
+  }
+
+  var query = dialect.getDeleteQuery(model, properties, whereClause);
 
   if (model.logQueries) {
     console.log(query.text);
@@ -310,7 +318,7 @@ function remove(model, id, callback) {
     if (dialect.getRemovedRowCount(result)) {
       callback(null, true);
     } else {
-      var msg = 'Row with id ' + id + ' was not found in ' + model.name;
+      var msg = 'Row with properties ' + JSON.stringify(properties) + ' was not found in ' + model.name;
       callback(new BoxError(404, msg));
     }
   });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -262,7 +262,7 @@ function describeModel(driver) {
         });
       });
 
-      it('should be able to remove a row', function (done) {
+      it('should be able to remove a row by id', function (done) {
         Person.remove(person.id, function (err, result) {
           expect(err).to.not.be.ok();
           expect(result).to.be(true);
@@ -270,8 +270,25 @@ function describeModel(driver) {
         });
       });
 
-      it('should return a 404 error when row not found', function (done) {
+      it('should be able to remove a row by query object', function (done) {
+        Person.remove({age: 25}, function (err, result) {
+          expect(err).to.not.be.ok();
+          expect(result).to.be(true);
+          done();
+        });
+      });
+
+      it('should return a 404 error when row not found by id', function (done) {
         Person.remove(person.id+1, function (err, result) {
+          expect(err).to.be.an(Error);
+          expect(err.code).to.be(404);
+          expect(result).to.be(undefined);
+          done();
+        });
+      });
+
+      it('should return a 404 error when row not found by query object', function (done) {
+        Person.remove({age: 900}, function (err, result) {
           expect(err).to.be.an(Error);
           expect(err.code).to.be(404);
           expect(result).to.be(undefined);


### PR DESCRIPTION
Remove can now accept an id or a query object:

```
User.remove(1, function (err, success) {
  // ...
});

User.remove({username: 'raycmorgan'}, function (err, success) {
  // ...
});
```
